### PR TITLE
EBD-520: Update Ambiq SPI driver to use full duplex

### DIFF
--- a/drivers/spi/spi_ambiq.c
+++ b/drivers/spi/spi_ambiq.c
@@ -175,6 +175,9 @@ static int spi_ambiq_xfer(const struct device *dev, const struct spi_config *con
 			trans.pui32RxBuffer = (uint32_t *)ctx->rx_buf;
 			trans.ui32NumBytes = ctx->rx_len;
 			ret = am_hal_iom_blocking_transfer(data->IOMHandle, &trans);
+			if (ret < 0) {
+				break;
+			}
 			spi_context_update_rx(ctx, 1, ctx->rx_len);
 		} while (ctx->rx_len > 0);
 	}


### PR DESCRIPTION
There were a couple issues with the SPI driver that are fixed with this change
1. Previously was operating in half-duplex mode which makes it incompatible with and full duplex devices that are connected to the SPI bus. The default DTS configuration is also full-duplex which made the previous implementation a bit non-sensical
2. Only a single rx buffer could be given to the driver implementation even though the implementation should allow for multiple rx buffers to be supported.