### PR TITLE
EBD-492: Apollo3 low power support

### DIFF
--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -24,6 +24,24 @@
 		cpu0: cpu@0 {
 			compatible = "arm,cortex-m4f";
 			reg = <0>;
+			cpu-power-states = <&idle &suspend>;
+		};
+	};
+
+	power-states {
+		idle: sleep1 {
+			compatible = "zephyr,power-state";
+			power-state-name = "runtime-idle";
+			substate-id = <1>;
+			min-residency-us = <0>;
+		};
+
+		suspend: deepsleep1 {
+			compatible = "zephyr,power-state";
+			power-state-name = "suspend-to-idle";
+			substate-id = <2>;
+			min-residency-us = <5000000>;
+			exit-latency-us = <25>;
 		};
 	};
 

--- a/soc/arm/ambiq/apollo3x/CMakeLists.txt
+++ b/soc/arm/ambiq/apollo3x/CMakeLists.txt
@@ -4,6 +4,7 @@
 #
 
 zephyr_sources(soc.c)
+zephyr_sources_ifdef(CONFIG_PM power.c)
 zephyr_include_directories(${ZEPHYR_BASE}/soc/arm/common/cortex_m)
 
 set(SOC_LINKER_SCRIPT ${ZEPHYR_BASE}/include/zephyr/arch/arm/cortex_m/scripts/linker.ld CACHE INTERNAL "")

--- a/soc/arm/ambiq/apollo3x/Kconfig.series
+++ b/soc/arm/ambiq/apollo3x/Kconfig.series
@@ -13,6 +13,7 @@ config SOC_SERIES_APOLLO3X
 	select SOC_FAMILY_AMBIQ
 	select CPU_HAS_ARM_MPU
 	select HAS_SWO
+	select HAS_PM
 	select AMBIQ_HAL
 	help
 	  Enable support for Apollo3 MCU series

--- a/soc/arm/ambiq/apollo3x/power.c
+++ b/soc/arm/ambiq/apollo3x/power.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Semios Inc
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <zephyr/kernel.h>
+#include <zephyr/pm/pm.h>
+#include <soc.h>
+
+#include <am_mcu_apollo.h>
+
+#include <zephyr/logging/log.h>
+LOG_MODULE_DECLARE(power, CONFIG_PM_LOG_LEVEL);
+
+void pm_state_set(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(substate_id);
+
+	__disable_irq();
+	irq_unlock(0);
+
+	switch (state) {
+	case PM_STATE_RUNTIME_IDLE:
+		/* Sys sleep mode 1 */
+		am_hal_sysctrl_sleep(AM_HAL_SYSCTRL_SLEEP_NORMAL);
+		k_cpu_idle();
+		break;
+	case PM_STATE_SUSPEND_TO_IDLE:
+		/* Sys deep sleep mode 1 */
+		am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_CACHE);
+		am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_FLASH_2M);
+		am_hal_pwrctrl_memory_deepsleep_powerdown(AM_HAL_PWRCTRL_MEM_SRAM_MAX);
+		am_hal_pwrctrl_memory_deepsleep_retain(AM_HAL_PWRCTRL_MEM_SRAM_768K);
+		am_hal_sysctrl_control(AM_HAL_SYSCTRL_CONTROL_DEEPSLEEP_MINPWR_EN, 0);
+		am_hal_sysctrl_sleep(AM_HAL_SYSCTRL_SLEEP_DEEP);
+		k_cpu_idle();
+		break;
+	default:
+		break;
+	}
+}
+
+void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
+{
+	ARG_UNUSED(state);
+	ARG_UNUSED(substate_id);
+
+	__enable_irq();
+}

--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: 899ea4c72d33330c3a5d5b27bb54aad7377810f7
+      revision: b0f7395673908d4cbd2a796bba5d9198f8ee8d8d
       remote: semios
       repo-path: hal_ambiq.git
       path: modules/hal/ambiq


### PR DESCRIPTION
Added basic support for runtime-idle and suspend-to-idle states on the Ambiq Apollo3. When in suspend I measured the current draw to be 338uA which according to JB should be good enough. We can add further power optimizations by turning off sensors and peripherals once as we add more functionality.