### PR TITLE
drivers: counter: Add Apollo3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ BinaryFiles.txt
 Checkpatch.txt
 DevicetreeBindings.txt
 Gitlint.txt
+GitDiffCheck.txt
 Identity.txt
 ImageSize.txt
 Kconfig.txt

--- a/boards/arm/apollo3p_blue_evb/apollo3p_blue_evb.dts
+++ b/boards/arm/apollo3p_blue_evb/apollo3p_blue_evb.dts
@@ -84,6 +84,10 @@
 	status = "okay";
 };
 
+&counter1 {
+	status = "okay";
+};
+
 &wdt0 {
 	status = "okay";
 };

--- a/drivers/counter/counter_ambiq_timer.c
+++ b/drivers/counter/counter_ambiq_timer.c
@@ -16,49 +16,236 @@
 
 LOG_MODULE_REGISTER(ambiq_counter, CONFIG_COUNTER_LOG_LEVEL);
 
-static void counter_ambiq_isr(void *arg);
-
 #define TIMER_IRQ (DT_INST_IRQN(0))
+
+#define DEVICE_DT_GET_AND_COMMA(node_id) DEVICE_DT_GET(node_id),
+
+static void counter_ambiq_isr(void *arg);
 
 struct counter_ambiq_config {
 	struct counter_config_info counter_info;
+	uint32_t timer;
+	uint32_t clk;
+	uint32_t function;
 };
 
 struct counter_ambiq_data {
 	counter_alarm_callback_t callback;
 	void *user_data;
+	uint32_t ambiq_interrupt_status_bit;
+	uint32_t freq;
+	uint32_t guard;
+	bool started;
 };
 
+static const struct device *const devices[] = {
+	DT_FOREACH_STATUS_OKAY(ambiq_counter, DEVICE_DT_GET_AND_COMMA)};
+
 static struct k_spinlock lock;
+static bool irq_init = true;
+
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+static uint32_t get_ambiq_function(uint32_t function)
+{
+	switch (function) {
+	case 0:
+		return AM_HAL_CTIMER_FN_ONCE;
+	case 1:
+		return AM_HAL_CTIMER_FN_REPEAT;
+	case 2:
+		return AM_HAL_CTIMER_FN_PWM_ONCE;
+	case 3:
+		return AM_HAL_CTIMER_FN_PWM_REPEAT;
+	case 4:
+		return AM_HAL_CTIMER_FN_PTN_ONCE;
+	case 5:
+		return AM_HAL_CTIMER_FN_PTN_REPEAT;
+	case 6:
+		return AM_HAL_CTIMER_FN_CONTINUOUS;
+	case 7:
+		return AM_HAL_CTIMER_FN_PWM_ALTERNATE;
+	default:
+		return AM_HAL_CTIMER_FN_ONCE;
+	}
+}
+
+static uint32_t get_ambiq_interrupt_bit(uint32_t timer)
+{
+	switch (timer) {
+	case 0:
+		return AM_HAL_CTIMER_INT_TIMERA0C0;
+	case 1:
+		return AM_HAL_CTIMER_INT_TIMERA1C0;
+	case 2:
+		return AM_HAL_CTIMER_INT_TIMERA2C0;
+	case 3:
+		return AM_HAL_CTIMER_INT_TIMERA3C0;
+	case 4:
+		return AM_HAL_CTIMER_INT_TIMERA4C0;
+	case 5:
+		return AM_HAL_CTIMER_INT_TIMERA5C0;
+	case 6:
+		return AM_HAL_CTIMER_INT_TIMERA6C0;
+	case 7:
+		return AM_HAL_CTIMER_INT_TIMERA7C0;
+	default:
+		return AM_HAL_CTIMER_INT_TIMERA0C0;
+	}
+}
+
+static uint32_t get_ambiq_clk(uint32_t clk)
+{
+	switch (clk) {
+	case 0:
+		return AM_HAL_CTIMER_CLK_PIN;
+	case 1:
+		return AM_HAL_CTIMER_HFRC_12MHZ;
+	case 2:
+		return AM_HAL_CTIMER_HFRC_3MHZ;
+	case 3:
+		return AM_HAL_CTIMER_HFRC_187_5KHZ;
+	case 4:
+		return AM_HAL_CTIMER_HFRC_47KHZ;
+	case 5:
+		return AM_HAL_CTIMER_HFRC_12KHZ;
+	case 6:
+		return AM_HAL_CTIMER_XT_32_768KHZ;
+	case 7:
+		return AM_HAL_CTIMER_XT_16_384KHZ;
+	case 8:
+		return AM_HAL_CTIMER_XT_2_048KHZ;
+	case 9:
+		return AM_HAL_CTIMER_XT_256HZ;
+	case 10:
+		return AM_HAL_CTIMER_LFRC_512HZ;
+	case 11:
+		return AM_HAL_CTIMER_LFRC_32HZ;
+	case 12:
+		return AM_HAL_CTIMER_LFRC_1HZ;
+	case 13:
+		return AM_HAL_CTIMER_LFRC_1_16HZ;
+	case 14:
+		return AM_HAL_CTIMER_RTC_100HZ;
+	default:
+		return AM_HAL_CTIMER_CLK_PIN;
+	}
+}
+
+static uint32_t get_ambiq_clk_ctrl(uint32_t clk)
+{
+	switch (clk) {
+	case AM_HAL_CTIMER_CLK_PIN:
+		return -ENOTSUP;
+	case AM_HAL_CTIMER_HFRC_12MHZ:
+	case AM_HAL_CTIMER_HFRC_3MHZ:
+	case AM_HAL_CTIMER_HFRC_187_5KHZ:
+	case AM_HAL_CTIMER_HFRC_47KHZ:
+	case AM_HAL_CTIMER_HFRC_12KHZ:
+		return AM_HAL_CLKGEN_CONTROL_SYSCLK_MAX;
+	case AM_HAL_CTIMER_XT_32_768KHZ:
+	case AM_HAL_CTIMER_XT_16_384KHZ:
+	case AM_HAL_CTIMER_XT_2_048KHZ:
+	case AM_HAL_CTIMER_XT_256HZ:
+		return AM_HAL_CLKGEN_CONTROL_XTAL_START;
+	case AM_HAL_CTIMER_LFRC_512HZ:
+	case AM_HAL_CTIMER_LFRC_32HZ:
+	case AM_HAL_CTIMER_LFRC_1HZ:
+	case AM_HAL_CTIMER_LFRC_1_16HZ:
+		return AM_HAL_CLKGEN_CONTROL_LFRC_START;
+	case AM_HAL_CTIMER_RTC_100HZ:
+		return -ENOTSUP;
+	default:
+		return -ENOTSUP;
+	}
+}
+
+static uint32_t get_freq(uint32_t clk)
+{
+	switch (clk) {
+	case AM_HAL_CTIMER_CLK_PIN:
+		return 0;
+	case AM_HAL_CTIMER_HFRC_12MHZ:
+		return 12000000;
+	case AM_HAL_CTIMER_HFRC_3MHZ:
+		return 3000000;
+	case AM_HAL_CTIMER_HFRC_187_5KHZ:
+		return 1875000;
+	case AM_HAL_CTIMER_HFRC_47KHZ:
+		return 47000;
+	case AM_HAL_CTIMER_HFRC_12KHZ:
+		return 12000;
+	case AM_HAL_CTIMER_XT_32_768KHZ:
+		return 32768;
+	case AM_HAL_CTIMER_XT_16_384KHZ:
+		return 16384;
+	case AM_HAL_CTIMER_XT_2_048KHZ:
+		return 2048;
+	case AM_HAL_CTIMER_XT_256HZ:
+		return 256;
+	case AM_HAL_CTIMER_LFRC_512HZ:
+		return 512;
+	case AM_HAL_CTIMER_LFRC_32HZ:
+		return 32;
+	case AM_HAL_CTIMER_LFRC_1HZ:
+		return 1;
+	case AM_HAL_CTIMER_LFRC_1_16HZ:
+		return 1;
+	case AM_HAL_CTIMER_RTC_100HZ:
+		return 100;
+	default:
+		return 32768;
+	}
+};
+#endif
 
 static int counter_ambiq_init(const struct device *dev)
 {
-	am_hal_timer_config_t tc;
-
+	const struct counter_ambiq_config *config = dev->config;
+	struct counter_ambiq_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&lock);
 
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	data->ambiq_interrupt_status_bit = get_ambiq_interrupt_bit(config->timer);
+	data->freq = get_freq(get_ambiq_clk(config->clk));
+	am_hal_clkgen_control(get_ambiq_clk_ctrl(get_ambiq_clk(config->clk)), 0);
+	am_hal_ctimer_config_single(config->timer, AM_HAL_CTIMER_BOTH,
+				    (get_ambiq_function(config->function) |
+				     get_ambiq_clk(config->clk) | AM_HAL_CTIMER_INT_ENABLE));
+#else
+	am_hal_timer_config_t tc;
 	am_hal_timer_default_config_set(&tc);
 	tc.eInputClock = AM_HAL_TIMER_CLOCK_HFRC_DIV16;
 	tc.eFunction = AM_HAL_TIMER_FN_UPCOUNT;
 	tc.ui32PatternLimit = 0;
+	data->freq = 6000000;
 
 	am_hal_timer_config(0, &tc);
-
+#endif
 	k_spin_unlock(&lock, key);
 
-	NVIC_ClearPendingIRQ(TIMER_IRQ);
-	IRQ_CONNECT(TIMER_IRQ, 0, counter_ambiq_isr, DEVICE_DT_INST_GET(0), 0);
-	irq_enable(TIMER_IRQ);
+	if (irq_init) {
+		irq_init = false;
+		NVIC_ClearPendingIRQ(TIMER_IRQ);
+		IRQ_CONNECT(TIMER_IRQ, DT_INST_IRQ(0, priority), counter_ambiq_isr,
+			    DEVICE_DT_INST_GET(0), 0);
+
+		irq_enable(TIMER_IRQ);
+	}
 
 	return 0;
 }
 
 static int counter_ambiq_start(const struct device *dev)
 {
+	const struct counter_ambiq_config *config = dev->config;
+	struct counter_ambiq_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&lock);
-
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	am_hal_ctimer_start(config->timer, AM_HAL_CTIMER_BOTH);
+	data->started = true;
+#else
 	am_hal_timer_start(0);
-
+#endif
 	k_spin_unlock(&lock, key);
 
 	return 0;
@@ -66,9 +253,15 @@ static int counter_ambiq_start(const struct device *dev)
 
 static int counter_ambiq_stop(const struct device *dev)
 {
+	const struct counter_ambiq_config *config = dev->config;
+	struct counter_ambiq_data *data = dev->data;
 	k_spinlock_key_t key = k_spin_lock(&lock);
-
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	am_hal_ctimer_stop(config->timer, AM_HAL_CTIMER_BOTH);
+	data->started = false;
+#else
 	am_hal_timer_stop(0);
+#endif
 
 	k_spin_unlock(&lock, key);
 
@@ -77,55 +270,44 @@ static int counter_ambiq_stop(const struct device *dev)
 
 static int counter_ambiq_get_value(const struct device *dev, uint32_t *ticks)
 {
+	const struct counter_ambiq_config *config = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&lock);
-
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	*ticks = am_hal_ctimer_read(config->timer, AM_HAL_CTIMER_BOTH);
+#else
 	*ticks = am_hal_timer_read(0);
+#endif
 
 	k_spin_unlock(&lock, key);
 
 	return 0;
 }
 
-static int counter_ambiq_set_alarm(const struct device *dev, uint8_t chan_id,
-				   const struct counter_alarm_cfg *alarm_cfg)
+static int counter_ambiq_get_value_64(const struct device *dev, uint64_t *ticks)
 {
-	ARG_UNUSED(chan_id);
-	struct counter_ambiq_data *data = dev->data;
-	uint32_t now;
-
-	counter_ambiq_get_value(dev, &now);
-
+	const struct counter_ambiq_config *config = dev->config;
 	k_spinlock_key_t key = k_spin_lock(&lock);
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	*ticks = (uint64_t)am_hal_ctimer_read(config->timer, AM_HAL_CTIMER_BOTH);
+#else
+	*ticks = (uint64_t)am_hal_timer_read(0);
+#endif
 
-	/* Enable interrupt, due to counter_ambiq_cancel_alarm() disables it*/
-	am_hal_timer_interrupt_clear(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
-	am_hal_timer_interrupt_enable(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+	k_spin_unlock(&lock, key);
 
-	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
-		am_hal_timer_compare1_set(0, now + alarm_cfg->ticks);
+	return 0;
+}
+
+static uint32_t counter_ambiq_get_pending_int(const struct device *dev)
+{
+	const struct counter_ambiq_data *data = dev->data;
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	if ((data->ambiq_interrupt_status_bit & am_hal_ctimer_int_status_get(true)) != 0) {
+		return 1;
 	} else {
-		am_hal_timer_compare1_set(0, alarm_cfg->ticks);
+		return 0;
 	}
-
-	data->user_data = alarm_cfg->user_data;
-	data->callback = alarm_cfg->callback;
-
-	k_spin_unlock(&lock, key);
-
-	return 0;
-}
-
-static int counter_ambiq_cancel_alarm(const struct device *dev, uint8_t chan_id)
-{
-	ARG_UNUSED(chan_id);
-
-	k_spinlock_key_t key = k_spin_lock(&lock);
-
-	am_hal_timer_interrupt_disable(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
-	/* Reset the compare register */
-	am_hal_timer_compare1_set(0, 0);
-	k_spin_unlock(&lock, key);
-
+#endif
 	return 0;
 }
 
@@ -140,11 +322,6 @@ static int counter_ambiq_set_top_value(const struct device *dev, const struct co
 	}
 }
 
-static uint32_t counter_ambiq_get_pending_int(const struct device *dev)
-{
-	return 0;
-}
-
 static uint32_t counter_ambiq_get_top_value(const struct device *dev)
 {
 	const struct counter_ambiq_config *config = dev->config;
@@ -152,24 +329,180 @@ static uint32_t counter_ambiq_get_top_value(const struct device *dev)
 	return config->counter_info.max_top_value;
 }
 
+static int counter_ambiq_set_alarm(const struct device *dev, uint8_t chan_id,
+				   const struct counter_alarm_cfg *alarm_cfg)
+{
+	ARG_UNUSED(chan_id);
+	struct counter_ambiq_data *data = dev->data;
+	const struct counter_ambiq_config *config = dev->config;
+	uint32_t now;
+	uint32_t compare_val = 0;
+	uint32_t relative_guard = data->started ? data->guard : 0;
+	bool expire_now = false;
+	int ret = 0;
+
+	if (alarm_cfg->callback == NULL) {
+		return -EINVAL;
+	}
+	if (counter_ambiq_get_pending_int(dev)) {
+		return -EBUSY;
+	}
+
+	data->user_data = alarm_cfg->user_data;
+	data->callback = alarm_cfg->callback;
+
+	uint32_t top = counter_ambiq_get_top_value(dev);
+
+	counter_ambiq_get_value(dev, &now);
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+
+	if ((alarm_cfg->flags & COUNTER_ALARM_CFG_ABSOLUTE) == 0) {
+		if (alarm_cfg->ticks < relative_guard) {
+			expire_now = true;
+		} else {
+			if ((int64_t)top - ((int64_t)now + (int64_t)alarm_cfg->ticks +
+					    (int64_t)relative_guard) >
+			    0) {
+				compare_val = alarm_cfg->ticks + now;
+			} else {
+				compare_val = (now + alarm_cfg->ticks + data->guard) - top;
+			}
+		}
+	} else {
+		if (alarm_cfg->ticks >= (now + data->guard) % top) {
+			compare_val = alarm_cfg->ticks;
+		} else {
+			expire_now =
+				(alarm_cfg->flags & COUNTER_ALARM_CFG_EXPIRE_WHEN_LATE) ? 1 : 0;
+			ret = -ETIME;
+		}
+	}
+
+	/* Enable interrupt, due to counter_ambiq_cancel_alarm() disables it*/
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	am_hal_ctimer_int_clear(data->ambiq_interrupt_status_bit);
+	am_hal_ctimer_int_enable(data->ambiq_interrupt_status_bit);
+	if (expire_now) {
+		am_hal_ctimer_int_set(data->ambiq_interrupt_status_bit);
+	} else {
+		if (ret == 0) {
+			am_hal_ctimer_compare_set(config->timer,
+				AM_HAL_CTIMER_BOTH, 0, compare_val);
+		}
+	}
+#else
+	am_hal_timer_interrupt_clear(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+	am_hal_timer_interrupt_enable(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+
+	am_hal_timer_compare1_set(0, compare_val);
+#endif
+
+	k_spin_unlock(&lock, key);
+
+	return ret;
+}
+
+static int counter_ambiq_cancel_alarm(const struct device *dev, uint8_t chan_id)
+{
+	ARG_UNUSED(chan_id);
+
+	const struct counter_ambiq_config *config = dev->config;
+	struct counter_ambiq_data *data = dev->data;
+
+	if (data->started == false) {
+		return -ENOTSUP;
+	}
+
+	k_spinlock_key_t key = k_spin_lock(&lock);
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	am_hal_ctimer_int_disable(data->ambiq_interrupt_status_bit);
+	/* Reset the compare register */
+	am_hal_ctimer_compare_set(config->timer, AM_HAL_CTIMER_BOTH, 0, 0);
+#else
+	am_hal_timer_interrupt_disable(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+	/* Reset the compare register */
+	am_hal_timer_compare1_set(0, 0);
+#endif
+	k_spin_unlock(&lock, key);
+
+	return 0;
+}
+
+static uint32_t counter_ambiq_get_freq(const struct device *dev)
+{
+	const struct counter_ambiq_data *data = dev->data;
+
+	return data->freq;
+}
+
+static int counter_ambiq_set_guard_period(const struct device *dev, uint32_t ticks, uint32_t flags)
+{
+	ARG_UNUSED(flags);
+	struct counter_ambiq_data *data = dev->data;
+
+	/* max guard period half of max counter value */
+	if (ticks >= (counter_ambiq_get_top_value(dev) / 2)) {
+		return -EINVAL;
+	}
+	data->guard = ticks;
+	return 0;
+}
+
+static uint32_t counter_ambiq_get_guard_period(const struct device *dev, uint32_t flags)
+{
+	ARG_UNUSED(flags);
+	const struct counter_ambiq_data *data = dev->data;
+
+	return data->guard;
+}
+
 static const struct counter_driver_api counter_api = {
 	.start = counter_ambiq_start,
 	.stop = counter_ambiq_stop,
 	.get_value = counter_ambiq_get_value,
+	.get_value_64 = counter_ambiq_get_value_64,
 	.set_alarm = counter_ambiq_set_alarm,
 	.cancel_alarm = counter_ambiq_cancel_alarm,
 	.set_top_value = counter_ambiq_set_top_value,
 	.get_pending_int = counter_ambiq_get_pending_int,
 	.get_top_value = counter_ambiq_get_top_value,
+	.get_freq = counter_ambiq_get_freq,
+	.set_guard_period = counter_ambiq_set_guard_period,
+	.get_guard_period = counter_ambiq_get_guard_period,
 };
+
+static const struct device *counter_ambiq_get_device(uint32_t interrupt)
+{
+	for (int i = 0; i < ARRAY_SIZE(devices); i++) {
+		struct counter_ambiq_data *data = devices[i]->data;
+
+		if (data->ambiq_interrupt_status_bit == interrupt) {
+			return devices[i];
+		}
+	}
+	return NULL;
+}
 
 static void counter_ambiq_isr(void *arg)
 {
+	uint32_t now = 0;
+#ifdef CONFIG_SOC_APOLLO3P_BLUE
+	const struct device *dev = counter_ambiq_get_device(am_hal_ctimer_int_status_get(true));
+
+	if (dev == NULL) {
+		return;
+	}
+	const struct counter_ambiq_data *data = dev->data;
+
+	am_hal_ctimer_int_disable(data->ambiq_interrupt_status_bit);
+	am_hal_ctimer_int_clear(data->ambiq_interrupt_status_bit);
+
+#else
 	const struct device *dev = (const struct device *)arg;
 	struct counter_ambiq_data *data = dev->data;
-	uint32_t now = 0;
-
 	am_hal_timer_interrupt_clear(AM_HAL_TIMER_MASK(0, AM_HAL_TIMER_COMPARE1));
+#endif
 	counter_ambiq_get_value(dev, &now);
 
 	if (data->callback) {
@@ -178,14 +511,18 @@ static void counter_ambiq_isr(void *arg)
 }
 
 #define AMBIQ_COUNTER_INIT(idx)                                                                    \
-                                                                                                   \
-	static struct counter_ambiq_data counter_data_##idx;                                       \
+	static struct counter_ambiq_data counter_data_##idx = {                                    \
+		.started = false,                                                                  \
+		.guard = 0,                                                                        \
+	};                                                                                         \
                                                                                                    \
 	static const struct counter_ambiq_config counter_config_##idx = {                          \
 		.counter_info = {.max_top_value = UINT32_MAX,                                      \
-				 .freq = 6000000,                                                  \
 				 .flags = COUNTER_CONFIG_INFO_COUNT_UP,                            \
 				 .channels = 1},                                                   \
+		.timer = DT_PROP(DT_INST(idx, ambiq_counter), timer),                              \
+		.clk = DT_PROP(DT_INST(idx, ambiq_counter), counter_clock),                        \
+		.function = DT_PROP(DT_INST(idx, ambiq_counter), counter_function),                \
 	};                                                                                         \
                                                                                                    \
 	DEVICE_DT_INST_DEFINE(idx, counter_ambiq_init, NULL, &counter_data_##idx,                  \

--- a/drivers/rtc/Kconfig.ambiq
+++ b/drivers/rtc/Kconfig.ambiq
@@ -3,7 +3,7 @@
 
 config RTC_AMBIQ
 	bool "Ambiq RTC driver"
-	default y if !COUNTER
+	default y
 	depends on DT_HAS_AMBIQ_RTC_ENABLED && !SOC_SERIES_APOLLO4X
 	help
 	  Build RTC driver for Ambiq SoCs, excluding Apollo4 series.

--- a/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
+++ b/dts/arm/ambiq/ambiq_apollo3p_blue.dtsi
@@ -95,9 +95,82 @@
 
 		counter0: counter@40008000 {
 			compatible = "ambiq,counter";
-			reg = <0x40008000 0x80>;
+			reg = <0x40008000 0x20>;
 			interrupts = <14 0>;
 			status = "disabled";
+			timer = <0>;
+			counter_clock = <6>;
+			counter_function = <1>;
+		};
+
+		counter1: counter@40008020 {
+			compatible = "ambiq,counter";
+			reg = <0x40008020 0x20>;
+			interrupts = <14 0>;
+			status = "disabled";
+			timer = <1>;
+			counter_clock = <6>;
+			counter_function = <1>;
+		};
+
+		counter2: counter@40008040 {
+			compatible = "ambiq,counter";
+			reg = <0x40008040 0x20>;
+			interrupts = <14 0>;
+			status = "disabled";
+			timer = <2>;
+			counter_clock = <6>;
+			counter_function = <1>;
+		};
+
+		counter3: counter@40008060 {
+			compatible = "ambiq,counter";
+			reg = <0x40008060 0x20>;
+			interrupts = <14 0>;
+			status = "disabled";
+			timer = <3>;
+			counter_clock = <6>;
+			counter_function = <1>;
+		};
+
+		counter4: counter@40008080 {
+			compatible = "ambiq,counter";
+			reg = <0x40008080 0x20>;
+			interrupts = <14 0>;
+			status = "disabled";
+			timer = <4>;
+			counter_clock = <6>;
+			counter_function = <1>;
+		};
+
+		counter5: counter@400080a0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080a0 0x20>;
+			interrupts = <14 0>;
+			status = "disabled";
+			timer = <5>;
+			counter_clock = <6>;
+			counter_function = <1>;
+		};
+
+		counter6: counter@400080c0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080c0 0x20>;
+			interrupts = <14 0>;
+			status = "disabled";
+			timer = <6>;
+			counter_clock = <6>;
+			counter_function = <1>;
+		};
+
+		counter7: counter@400080e0 {
+			compatible = "ambiq,counter";
+			reg = <0x400080e0 0x20>;
+			interrupts = <14 0>;
+			status = "disabled";
+			timer = <7>;
+			counter_clock = <6>;
+			counter_function = <1>;
 		};
 
 		uart0: uart@4001c000 {

--- a/dts/bindings/counter/ambiq,counter.yaml
+++ b/dts/bindings/counter/ambiq,counter.yaml
@@ -13,3 +13,43 @@ properties:
 
   interrupts:
     required: true
+
+  timer:
+    required: true
+    type: int
+    description: Timer number
+
+  counter_clock:
+    required: true
+    type: int
+    description: Clock source
+    enum:
+      - 0 # AM_HAL_CTIMER_CLK_PIN
+      - 1 # AM_HAL_CTIMER_HFRC_12MHZ
+      - 2 # AM_HAL_CTIMER_HFRC_3MHZ
+      - 3 # AM_HAL_CTIMER_HFRC_187_5KHZ
+      - 4 # AM_HAL_CTIMER_HFRC_47KHZ
+      - 5 # AM_HAL_CTIMER_HFRC_12KHZ
+      - 6 # AM_HAL_CTIMER_XT_32_768KHZ
+      - 7 # AM_HAL_CTIMER_XT_16_384KHZ
+      - 8 # AM_HAL_CTIMER_XT_2_048KHZ
+      - 9 # AM_HAL_CTIMER_XT_256HZ
+      - 10 # AM_HAL_CTIMER_LFRC_512HZ
+      - 11 # AM_HAL_CTIMER_LFRC_32HZ
+      - 12 # AM_HAL_CTIMER_LFRC_1HZ
+      - 13 # AM_HAL_CTIMER_LFRC_1_16HZ
+      - 14 # AM_HAL_CTIMER_RTC_100HZ
+
+  counter_function:
+    required: true
+    type: int
+    description: Counter function pattern
+    enum:
+      - 0 # AM_HAL_CTIMER_FN_ONCE
+      - 1 # AM_HAL_CTIMER_FN_REPEAT
+      - 2 # AM_HAL_CTIMER_FN_PWM_ONCE
+      - 3 # AM_HAL_CTIMER_FN_PWM_REPEAT
+      - 4 # AM_HAL_CTIMER_FN_PTN_ONCE
+      - 5 # AM_HAL_CTIMER_FN_PTN_REPEAT
+      - 6 # AM_HAL_CTIMER_FN_CONTINUOUS
+      - 7 # AM_HAL_CTIMER_FN_PWM_ALTERNATE

--- a/west.yml
+++ b/west.yml
@@ -144,7 +144,7 @@ manifest:
       groups:
         - hal
     - name: hal_ambiq
-      revision: b0f7395673908d4cbd2a796bba5d9198f8ee8d8d
+      revision: 16ce2da6eb59289befd78a280862c9580083f31b
       remote: semios
       repo-path: hal_ambiq.git
       path: modules/hal/ambiq


### PR DESCRIPTION
Added support for Apollo3 ctimers. Changed Ambiq RTC Kconfig to prevent it from forcing CONFIG_COUNTER=n if it is enabled. Updated the west manifest to build AmbiqSDK files for ctimer.

The API and unit tests for the counter seems to expect that the timer runs continuously, triggering an interrupt every time the set value is passed. The Apollo3 does not support this - once it hits the compare register, the timer resets itself to 0 (or some variation on this, depending on the mode). As a default, I've set all the registers to default to "continuous mode", which is the closest operation to the desired behaviour. Additionally, I reused the guard period for relative tick_values to protect against missing an interrupt if the timer is already running, as it takes some time to set up the alarm.